### PR TITLE
updated Maven repo URLs in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
 
   <distributionManagement>
     <repository>
-      <id>maven.jenkins-ci.org</id>
-      <url>http://maven.jenkins-ci.org:8081/content/repositories/releases/</url>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/releases/</url>
     </repository>
   </distributionManagement>
 
@@ -263,8 +263,8 @@
       </releases>
     </repository>
     <repository>
-      <id>maven.jenkins-ci.org</id>
-      <url>http://maven.jenkins-ci.org/content/groups/artifacts/</url>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
   <properties>


### PR DESCRIPTION
The URL seem to be out of date, when compared to https://wiki.jenkins-ci.org/display/JENKINS/Plugin+tutorial#Plugintutorial-SettingUpEnvironment
